### PR TITLE
Changed way abbreviation and Party initials are generated

### DIFF
--- a/Classes/Models/SLFParty.h
+++ b/Classes/Models/SLFParty.h
@@ -25,12 +25,12 @@ typedef enum {
 + (SLFParty *)partyWithName:(NSString *)aName;
 + (SLFParty *)partyWithType:(SLFPartyType)aType;
 @property (nonatomic,copy) NSString *name;
+@property (nonatomic,copy) NSString *initial;
+@property (nonatomic,copy) NSString *abbreviation;
 @property (nonatomic,assign) SLFPartyType type;
 @property (nonatomic,retain) UIImage *image;
 @property (nonatomic,assign) NSUInteger pinColorIndex;
 @property (nonatomic,retain) UIColor *color;
-@property (nonatomic,readonly) NSString *initial;
-@property (nonatomic,readonly) NSString *abbreviation;
 @property (nonatomic,readonly) NSString *plural;
 @end
 

--- a/Classes/Models/SLFParty.m
+++ b/Classes/Models/SLFParty.m
@@ -29,6 +29,8 @@ static UnknownParty * cachedUnknown;
 
 @implementation SLFParty
 @synthesize name;
+@synthesize abbreviation;
+@synthesize initial;
 @synthesize type;
 @synthesize color;
 @synthesize image;
@@ -53,18 +55,12 @@ static UnknownParty * cachedUnknown;
 }
 
 - (void)dealloc {
+    self.abbreviation = nil;
+    self.initial = nil;
     self.name = nil;
     self.image = nil;
     self.color = nil;
     [super dealloc];
-}
-
-- (NSString *)initial {
-    return [self.name substringToIndex:1];
-}
-
-- (NSString *)abbreviation {
-    return [self.name substringToIndex:3];
 }
 
 - (NSString *)plural {
@@ -74,12 +70,15 @@ static UnknownParty * cachedUnknown;
 @end
 
 #define DEMOCRAT_STRING     NSLocalizedString(@"Democrat",@"")
-
+#define DEMOCRAT_INIT_STRING     NSLocalizedString(@"D",@"")
+#define DEMOCRAT_ABREVIATION_STRING     NSLocalizedString(@"Dem",@"")
 @implementation Democrat
 + (Democrat *)democrat {
     if (!cachedDemocrat) {
         cachedDemocrat = [[Democrat alloc] init];
         cachedDemocrat.type = SLFPartyDemocrat;
+        cachedDemocrat.initial = DEMOCRAT_INIT_STRING;
+        cachedDemocrat.abbreviation = DEMOCRAT_ABREVIATION_STRING;
         cachedDemocrat.name = DEMOCRAT_STRING;
         cachedDemocrat.color = [SLFAppearance partyBlue];
         cachedDemocrat.image = [UIImage imageNamed:@"bluestar"];
@@ -90,13 +89,16 @@ static UnknownParty * cachedUnknown;
 @end
 
 #define REPUBLICAN_STRING   NSLocalizedString(@"Republican", @"")
-
+#define REPUBLICAN_INIT_STRING     NSLocalizedString(@"R",@"")
+#define REPUBLICAN_ABREVIATION_STRING     NSLocalizedString(@"Rep",@"")
 @implementation Republican
 + (Republican *)republican {
     if (!cachedRepublican) {
         cachedRepublican = [[Republican alloc] init];
         cachedRepublican.type = SLFPartyRepublican;
         cachedRepublican.name = REPUBLICAN_STRING;
+        cachedRepublican.initial = REPUBLICAN_INIT_STRING;
+        cachedRepublican.abbreviation = REPUBLICAN_ABREVIATION_STRING;
         cachedRepublican.color = [SLFAppearance partyRed];
         cachedRepublican.image = [UIImage imageNamed:@"redstar"];
         cachedRepublican.pinColorIndex = SLFMapPinColorRed;
@@ -104,14 +106,18 @@ static UnknownParty * cachedUnknown;
     return cachedRepublican;
 }
 @end
-#define NEWPROGRESSIVE_STRING   NSLocalizedString(@"New Progressive Party", @"")
 
+#define NEWPROGRESSIVE_STRING   NSLocalizedString(@"New Progressive Party", @"")
+#define NEWPROGRESSIVE_INIT_STRING   NSLocalizedString(@"PNP", @"")
+#define NEWPROGRESSIVE_ABREVIATION_STRING   NSLocalizedString(@"PNP", @"")
 @implementation NewProgressiveParty
 + (NewProgressiveParty *)newprogressiveparty {
     if (!cachedNewProgressiveParty) {
         cachedNewProgressiveParty = [[NewProgressiveParty alloc] init];
         cachedNewProgressiveParty.type = SLFPartyNewProgressive;
         cachedNewProgressiveParty.name = NEWPROGRESSIVE_STRING;
+        cachedNewProgressiveParty.initial = NEWPROGRESSIVE_INIT_STRING;
+        cachedNewProgressiveParty.abbreviation = NEWPROGRESSIVE_ABREVIATION_STRING;
         cachedNewProgressiveParty.color = [SLFAppearance partyBlue];
         cachedNewProgressiveParty.image = [UIImage imageNamed:@"bluestar"];
         cachedNewProgressiveParty.pinColorIndex = SLFMapPinColorBlue;
@@ -119,14 +125,18 @@ static UnknownParty * cachedUnknown;
     return cachedNewProgressiveParty;
 }
 @end
-#define POPULARDEMOCRATIC_STRING   NSLocalizedString(@"Popular Democratic Party", @"")
 
+#define POPULARDEMOCRATIC_STRING   NSLocalizedString(@"Popular Democratic Party", @"")
+#define POPULARDEMOCRATIC_INIT_STRING   NSLocalizedString(@"PPD", @"")
+#define POPULARDEMOCRATIC_ABREVIATION_STRING   NSLocalizedString(@"PPD", @"")
 @implementation PopularDemocraticParty
 + (PopularDemocraticParty *)populardemocraticparty {
     if (!cachedPopularDemocraticParty) {
         cachedPopularDemocraticParty = [[PopularDemocraticParty alloc] init];
         cachedPopularDemocraticParty.type = SLFPartyPopularDemocratic;
         cachedPopularDemocraticParty.name = POPULARDEMOCRATIC_STRING;
+        cachedPopularDemocraticParty.initial = POPULARDEMOCRATIC_INIT_STRING;
+        cachedPopularDemocraticParty.abbreviation = POPULARDEMOCRATIC_ABREVIATION_STRING;
         cachedPopularDemocraticParty.color = [SLFAppearance partyRed];
         cachedPopularDemocraticParty.image = [UIImage imageNamed:@"redstar"];
         cachedPopularDemocraticParty.pinColorIndex = SLFMapPinColorRed;
@@ -136,13 +146,16 @@ static UnknownParty * cachedUnknown;
 @end
 
 #define INDEPENDENT_STRING   NSLocalizedString(@"Independent", @"")
-
+#define INDEPENDENT_INIT_STRING   NSLocalizedString(@"Ind", @"")
+#define INDEPENDENT_ABREVIATION_STRING   NSLocalizedString(@"I", @"")
 @implementation Independent
 + (Independent *)independent {
     if (!cachedIndependent) {
         cachedIndependent = [[Independent alloc] init];
         cachedIndependent.type = SLFPartyIndependent;
         cachedIndependent.name = INDEPENDENT_STRING;
+        cachedIndependent.initial = INDEPENDENT_INIT_STRING;
+        cachedIndependent.abbreviation = INDEPENDENT_ABREVIATION_STRING;
         cachedIndependent.color = [SLFAppearance partyGreen];
         cachedIndependent.image = [UIImage imageNamed:@"silverstar"];
         cachedIndependent.pinColorIndex = SLFMapPinColorGreen;
@@ -152,26 +165,19 @@ static UnknownParty * cachedUnknown;
 @end
 
 #define UNKNOWN_STRING   @""
-
 @implementation UnknownParty
 + (UnknownParty *)unknownParty {
     if (!cachedUnknown) {
         cachedUnknown = [[UnknownParty alloc] init];
         cachedUnknown.type = SLFPartyUnknown;
+        cachedUnknown.initial = UNKNOWN_STRING;
+        cachedUnknown.abbreviation = UNKNOWN_STRING;
         cachedUnknown.name = UNKNOWN_STRING;
         cachedUnknown.color = [SLFAppearance partyWhite];
         cachedUnknown.image = [UIImage imageNamed:@"silverstar"];
         cachedUnknown.pinColorIndex = SLFMapPinColorGreen;
     }
     return cachedUnknown;
-}
-
-- (NSString *)initial {
-    return UNKNOWN_STRING;
-}
-
-- (NSString *)abbreviation {
-    return UNKNOWN_STRING;
 }
 
 - (NSString *)plural {
@@ -181,21 +187,20 @@ static UnknownParty * cachedUnknown;
 
 
 SLFPartyType partyTypeForName(NSString *newName) {
-    SLFPartyType newType = SLFPartyUnknown;
     if (!IsEmpty(newName)) {
         NSString *loweredName = [newName lowercaseString];
         if ([@"democrat" isEqualToString:loweredName])
-            newType = SLFPartyDemocrat;
+            return SLFPartyDemocrat;
         else if ([@"republican" isEqualToString:loweredName])
-            newType = SLFPartyRepublican;
+            return SLFPartyRepublican;
         else if ([@"independent" isEqualToString:loweredName])
-            newType = SLFPartyIndependent;
+            return SLFPartyIndependent;
         else if ([@"partido nuevo progresista" isEqualToString:loweredName])
-            newType = SLFPartyNewProgressive;
+            return SLFPartyNewProgressive;
         else if ([@"partido popular democrático" isEqualToString:loweredName])
-            newType = SLFPartyPopularDemocratic;
+            return SLFPartyPopularDemocratic;
     }
-    return newType;
+    return SLFPartyUnknown;
 }
 
 NSString* partyNameForType(SLFPartyType aType) {


### PR DESCRIPTION
Hello,
The political partys in puerto rico can not be abbreviated or initial by a substring 3 or 1.
So i created a new base class member that derived classes fill with the correct abbreviation for each parties.
